### PR TITLE
Update sysinfo

### DIFF
--- a/files/scripts/sysinfo
+++ b/files/scripts/sysinfo
@@ -46,7 +46,7 @@ if [[ -f "/sys/devices/system/cpu/present" ]]; then
 	cpu_hwinfo;
 fi
 echo -e "Governor:   " $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
-echo -e "Memory:     " $(free -h | sed 's/i//g' | sed 's/Mem://g' | awk '{print $1" "$2}' | sed -n 'n;p')
+echo -e "Memory:     " $(free -h | grep 'Sp\|Mem' | awk '{print $2}' | sed 's/i//g')
 echo -e "Entropy:    " $(cat /proc/sys/kernel/random/entropy_avail)
 echo -e "Uptime:     " $(uptime)
 }


### PR DESCRIPTION
On german locale this breaks wording (Speicher = Memory):
```bash
root@nanopir5s:/home/npi# echo -e "Memory:     " $(free -h | sed 's/i//g' | sed 's/Mem://g' | awk '{print $1" "$2}' | sed -n 'n;p')
Memory:      Specher: 1,9G
```

```bash
npi@nanopir5s:~$ free -h | grep 'Sp\|Mem' | awk '{print $2}' | sed 's/i//g'
1,9G
```

```bash
npi@nanopir5s:~$ echo -e "Memory:     " $(free -h | grep 'Sp\|Mem' | awk '{print $2}' | sed 's/i//g')
Memory:      1,9G
```