### PR TITLE
Increased delay to fix filesystem busy error

### DIFF
--- a/lib/function/shrink
+++ b/lib/function/shrink
@@ -51,7 +51,7 @@ mount "${ROOTFS}" p1
 p1_uuid
 echo ""
 extlinux
-sleep 1s
+sleep 3s
 echo ""
 umount p1
 rm -fdr p1


### PR DESCRIPTION
Build would error out with filesystem busy most of the times with the 1s delay in shrink prior to umount command.  So Increased it to 3 seconds and all seems good.