### PR TITLE
Added NetworkManager connectivity package

### DIFF
--- a/files/scripts/menu-config
+++ b/files/scripts/menu-config
@@ -273,7 +273,7 @@ sudo apt-get update; sudo apt-get -y upgrade
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 
 # install HA required packages
-sudo apt -y install jq libglib2.0-bin udisks2 network-manager
+sudo apt -y install jq libglib2.0-bin udisks2 network-manager network-manager-config-connectivity-debian
 
 # install agent required by ha
 wget -cq --show-progress \


### PR DESCRIPTION
Additional package that appears to be required for latest HA supervisor install
network-manager-config-connectivity-debian
