### PR TITLE
nanopi-r5s: add `pcie_aspm=off`

### DIFF
--- a/lib/boards/nanopir5s
+++ b/lib/boards/nanopir5s
@@ -40,7 +40,7 @@ OUTPUT="output/${BOARD}"
 
 # cmdline
 CONSOLE="console=tty1 console=ttyS2,115200n8 console=both"
-EXTRA="net.ifnames=0"
+EXTRA="net.ifnames=0 pcie_aspm=off"
 
 # motd
 DEFAULT_MOTD="NanoPi R5S"


### PR DESCRIPTION
Fix #56 

Signed-off-by: Ryan Northey <ryan@synca.io>