### PR TITLE
X96-AIR: `SD / USB boot is now vendor compatible`

### DIFF
--- a/files/boot/uboot/x96air/README.md
+++ b/files/boot/uboot/x96air/README.md
@@ -1,8 +1,10 @@
 #### NOTE
 ```sh
-These are no longer used. The board is currently using U-Boot v2023.01.
+This is only required for SD boot, when Vendor U-Boot is on the eMMC.
+Enable `EMMC=1` in the `userdata.txt` file to bypass and boot mainline.
 ```
+
 ```sh
-scripts and mainline boot bins from: https://github.com/hexdump0815
+Scripts and mainline boot bins from: https://github.com/hexdump0815
 https://github.com/hexdump0815/imagebuilder/releases/tag/210805-01
 ```

--- a/files/scripts/write2mmc
+++ b/files/scripts/write2mmc
@@ -471,6 +471,7 @@ if [[ "$P_VALUE" == "p2" ]]; then
 	cp -fr /boot/* /mnt/${P_BOOT}/
 	if [[ "$BOARD" == "x96air" ]]; then
 		rm -f /mnt/${P_BOOT}/{aml_autoscript,aml_autoscript.cmd,s905_autoscript,s905_autoscript.cmd,chainload.bin}
+		rm -fdr /mnt/${P_BOOT}/{LOST.DIR,Android}
 	fi
 fi
 rsync -apvx --progress --stats --human-readable . /mnt/${P_ROOTFS} > /dev/null
@@ -479,6 +480,7 @@ if [[ "$P_VALUE" == "p1" ]]; then
 	cp -fr /boot/* /mnt/${P_ROOTFS}/boot/
 	if [[ "$BOARD" == "x96air" ]]; then
 		rm -f /mnt/${P_ROOTFS}/boot/{aml_autoscript,aml_autoscript.cmd,s905_autoscript,s905_autoscript.cmd,chainload.bin}
+		rm -fdr /mnt/${P_ROOTFS}/boot/{LOST.DIR,Android}
 	fi
 fi
 if [[ "$P_VALUE" == "p2" ]]; then

--- a/files/scripts/write2mmc
+++ b/files/scripts/write2mmc
@@ -469,11 +469,17 @@ transfer (){
 cd /
 if [[ "$P_VALUE" == "p2" ]]; then
 	cp -fr /boot/* /mnt/${P_BOOT}/
+	if [[ "$BOARD" == "x96air" ]]; then
+		rm -f /mnt/${P_BOOT}/{aml_autoscript,aml_autoscript.cmd,s905_autoscript,s905_autoscript.cmd,chainload.bin}
+	fi
 fi
 rsync -apvx --progress --stats --human-readable . /mnt/${P_ROOTFS} > /dev/null
 if [[ "$P_VALUE" == "p1" ]]; then
 	mkdir -p /mnt/${P_ROOTFS}/boot
 	cp -fr /boot/* /mnt/${P_ROOTFS}/boot/
+	if [[ "$BOARD" == "x96air" ]]; then
+		rm -f /mnt/${P_ROOTFS}/boot/{aml_autoscript,aml_autoscript.cmd,s905_autoscript,s905_autoscript.cmd,chainload.bin}
+	fi
 fi
 if [[ "$P_VALUE" == "p2" ]]; then
 	rm -fdr /mnt/${P_ROOTFS}/boot/*

--- a/lib/boards/x96air
+++ b/lib/boards/x96air
@@ -19,8 +19,8 @@ UBOOT_DEFCONFIG="x96air-gbit_defconfig"
 # partition scheme
 GPT="false"
 EFI="false"
-VFAT="false"
-P_VALUE="p1"
+VFAT="true"
+P_VALUE="p2"
 OFFSET="8192"
 
 # boot config

--- a/scripts/stage1
+++ b/scripts/stage1
@@ -238,6 +238,11 @@ if [[ "$P_VALUE" == "p2" ]]; then
 		# odroid c1
 		odroid_bootini > /dev/null 2>&1
 	fi
+	if [[ "$BOARD" == "x96air" ]] && [[ "$EMMC" == "0" ]]; then
+		cp -fr files/boot/uboot/${BOARD}/{aml_autoscript.cmd,s905_autoscript.cmd,chainload.bin} p1/
+		mkimage -C none -A arm -T script -d p1/aml_autoscript.cmd p1/aml_autoscript > /dev/null 2>&1
+		mkimage -C none -A arm -T script -d p1/s905_autoscript.cmd p1/s905_autoscript > /dev/null 2>&1
+	fi
 	if [[ "$ENABLE_SHRINK" == "true" ]] && [[ "$GPT" == "false" ]] && [[ "$FSTYPE" == "ext4" ]] && [[ "$ARCH" == "arm" ]]; then
 		# add removable 100mb file to ensure space on the img after shrinking
 		dd if="/dev/urandom" of="p2/block.img" bs=100MB count=1 > /dev/null 2>&1


### PR DESCRIPTION
Most if not all boxes will have a form of vendor u-boot installed to the eMMC. Be it a custom Linux distro or Android. By default when creating an image, it will now be compatible with the vendor u-boot on the eMMC.

* Bypass compatibility
```sh
There is no point in doing so unless you have the builder image, flashed or transferred to the eMMC.
userdata.txt switch: EMMC="1"
```

Once booted from SD or USB, run `sudo write2mmc` to commence the transfer.