### PR TITLE
HA update to menu-config

### DIFF
--- a/files/scripts/menu-config
+++ b/files/scripts/menu-config
@@ -347,7 +347,7 @@ sudo apt-get update; sudo apt-get -y upgrade
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 
 # install HA required packages
-sudo apt -y install jq libglib2.0-bin udisks2 network-manager network-manager-config-connectivity-debian
+sudo apt -y install jq libglib2.0-bin udisks2 systemd-resolved systemd/bullseye-backports libpam-systemd/bullseye-backports network-manager/bullseye-backports systemd-journal-remote/bullseye-backports 
 
 # install agent required by ha
 wget -cq --show-progress \


### PR DESCRIPTION
HA needs systemd-resolved, which bullseye-backports for systemd, libpam-systemd and network-manager to install.  