### PR TITLE
Rockchip: `Update u-boot build process for RK358X inclusion`

### DIFF
--- a/lib/boards/nanopir3s
+++ b/lib/boards/nanopir3s
@@ -31,7 +31,8 @@ PETITBOOT="false"
 BOOTINI="false"
 BOOTCMD="false"
 
-# arm trusted firmware
+# arm trusted firmware (To use the ATF elf instead of the RKBIN elf use "bl31.elf")
+ATF_EN="false"
 ATF_PLAT="rk3568"
 ATF_EXT="PLAT=${ATF_PLAT} bl31"
 RKBIN_COMMIT="a8008bfe3c9296f6e44d5aa221e865e450ed921d"

--- a/lib/boards/rock5b
+++ b/lib/boards/rock5b
@@ -9,14 +9,14 @@ ROOTFS_ARCH="rootfs-${ARCH_EXT}"
 STATIC="qemu-aarch64-static"
 
 # device information
-SERIES="rk3566"
+SERIES="rk3588"
 FAMILY="rockchip"
-FAMILY_EXT="rk356x"
-DTB="${SERIES}-radxa-zero-3w"
+FAMILY_EXT="rk358x"
+DTB="${SERIES}-rock5-5b"
 
 # default config
 LINUX_DEFCONFIG="rockchip64_defconfig"
-UBOOT_DEFCONFIG="radxa-zero-3-rk3566_defconfig"
+UBOOT_DEFCONFIG="rock5b-rk3588_defconfig"
 
 # partition scheme
 GPT="true"
@@ -33,15 +33,15 @@ BOOTCMD="false"
 
 # arm trusted firmware (To use the ATF elf instead of the RKBIN elf use "bl31.elf")
 ATF_EN="false"
-ATF_PLAT="rk3568"
+ATF_PLAT="rk3588"
 ATF_EXT="PLAT=${ATF_PLAT} bl31"
-RKBIN_COMMIT="a8008bfe3c9296f6e44d5aa221e865e450ed921d"
+RKBIN_COMMIT="f43a462e7a1429a9d407ae52b4745033034a6cf9"
 RKBIN_DIR="rkbin-${RKBIN_COMMIT}/bin/rk35"
-RKBIN_ELF="rk3568_bl31_v1.44.elf"
-RKBIN_RAM="rk3566_ddr_1056MHz_v1.21.bin"
+RKBIN_ELF="rk3588_bl31_v1.48.elf"
+RKBIN_RAM="rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.18.bin"
 
 # output
-BOARD="radxazero3w"
+BOARD="rock5b"
 OUTPUT="output/${BOARD}"
 
 # extlinux and bootcmd
@@ -51,16 +51,16 @@ BOOTCMD_FDTOVERLAYS=""
 EXTLINUX_FDTOVERLAYS="#fdtoverlays"
 
 # cmdline
-CONSOLE="console=tty1 console=ttyS2,115200n8"
+CONSOLE="console=tty1 console=ttyS2,1500000n8"
 LOGLEVEL="loglevel=1"
-EXTRA="net.ifnames=0 cma=16M"
+EXTRA="net.ifnames=0"
 
 # motd
-DEFAULT_MOTD="Radxa Zero 3W"
+DEFAULT_MOTD="Rock 5B"
 
 # customize
 #MODULES_BLACKLIST=""
-MODULES_LOAD="rfcomm aic8800_btlpm"
+#MODULES_LOAD=""
 
 # patches
 LINUX_PATCHING="true"
@@ -94,11 +94,11 @@ GIT_PATCHDIR="patches/git/${BOARD}/${GIT_REPO}-${GIT_BRANCH}"
 
 # override userdata file
 FORCE_VERSION="true"
-FORCE_LINUX_VERSION="6.12.y"
-FORCE_UBOOT_VERSION="v2025.04"
+FORCE_LINUX_VERSION="stable"
+FORCE_UBOOT_VERSION="v2025.07"
 
 # devicetree and platform
-DEVICETREE="${DTB}.dtb ${SERIES}-radxa-zero-3e.dtb"
+DEVICETREE="${DTB}.dtb"
 PLATFORM="${FAMILY}"
 
 # kernel package name (if shared patching set to true)

--- a/lib/function/atf
+++ b/lib/function/atf
@@ -4,7 +4,7 @@
 arm_trusted_firmware (){
 TAG="lts-v2.12.1"
 GIT_ATF_URL="https://github.com/ARM-software/arm-trusted-firmware.git"
-if [[ "$FAMILY_EXT" =~ ^(sun50i|rk356x)$ ]]; then
+if [[ "$FAMILY_EXT" =~ ^(sun50i|rk356x|rk358x)$ ]]; then
 	atf_download; cd arm-trusted-firmware-${TAG}; atf_patching; echo ""
 	if [ $CROSSCOMPILE -eq 1 ]; then
 		echo -e "${GRN}  CC${FIN}"

--- a/lib/function/rockchip
+++ b/lib/function/rockchip
@@ -2,17 +2,19 @@
 
 # ATF BINARY
 atf_bl31 (){ # place bl31 file.
-if [[ -f "../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf" ]]; then
-	cp ../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf bl31.elf
-	cp ../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf atf-bl31
-else
-		report_atf_error
+if [[ "$ATF_EN" == "true" ]]; then
+	if [[ -f "../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf" ]]; then
+		cp ../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf bl31.elf
+		cp ../arm-trusted-firmware-${TAG}/build/${ATF_PLAT}/release/bl31/bl31.elf atf-bl31
+	else
+			report_atf_error
+	fi
 fi
-if [[ -f "${RKBIN_ELF}" ]] && [[ -f "../${RKBIN_DIR}/${RKBIN_RAM}" ]]; then
-	export BL31="${RKBIN_ELF}"
+if [[ "$ATF_EN" == "true" ]] && [[ -f "${RKBIN_ELF}" ]] && [[ -f "../${RKBIN_DIR}/${RKBIN_RAM}" ]]; then
+	export BL31="${RKBIN_ELF}" # ATF elf
 	export ROCKCHIP_TPL="../${RKBIN_DIR}/${RKBIN_RAM}"
-elif [[ -f "../${RKBIN_DIR}/${RKBIN_ELF}" ]] && [[ -f "../${RKBIN_DIR}/${RKBIN_RAM}" ]]; then
-	export BL31="../${RKBIN_DIR}/${RKBIN_ELF}"
+elif [[ "$ATF_EN" == "false" ]] && [[ -f "../${RKBIN_DIR}/${RKBIN_ELF}" ]] && [[ -f "../${RKBIN_DIR}/${RKBIN_RAM}" ]]; then
+	export BL31="../${RKBIN_DIR}/${RKBIN_ELF}" # RKBIN elf
 	export ROCKCHIP_TPL="../${RKBIN_DIR}/${RKBIN_RAM}"
 else
 		report_error
@@ -72,8 +74,8 @@ fi
 
 rockchip_uboot_run (){
 sources_dir
-if [[ "$FAMILY_EXT" =~ ^(rk356x)$ ]]; then rockchip_loader_binaries; fi
-arm_trusted_firmware
+if [[ "$FAMILY_EXT" =~ ^(rk356x|rk358x)$ ]]; then rockchip_loader_binaries; fi
+if [[ "$ATF_EN" == "true" ]]; then arm_trusted_firmware; fi
 uboot_run
 uboot_output
 }


### PR DESCRIPTION
Added a generic rock5b board conf as an example for future adds. There are currently no patches in place for u-boot or the kernel.

U-Boot: set to `v2025.07`
Kernel: set to `stable`

The current linux defconfig may or may not need to be updated to work with RK358X.